### PR TITLE
Add get max length functions

### DIFF
--- a/user-settings/include/user_settings.h
+++ b/user-settings/include/user_settings.h
@@ -356,6 +356,32 @@ uint16_t user_settings_key_to_id(const char *key);
  */
 const char *user_settings_id_to_key(uint16_t id);
 
+/**
+ * @brief Get maximal length of the setting 
+ *
+ * This will assert if no setting with the provided key exists.
+ * If the key input for this function is unknown to the application (i.e. parsed from user), then
+ * it should first be checked with user_settings_exists_with_key().
+ *
+ * @param[in] key A valid user setting key
+ *
+ * @return The length of the setting value.
+ */
+size_t user_settings_get_max_len_with_key(const char *key);
+
+/**
+ * @brief Get maximal length of the setting 
+ *
+ * This will assert if no setting with the provided id exists.
+ * If the ID input for this function is unknown to the application (i.e. parsed from user), then
+ * it should first be checked with user_settings_exists_with_id().
+ *
+ * @param[in] id A valid user setting id
+ *
+ * @return The length of the setting value.
+ */
+size_t user_settings_get_max_len_with_id(uint16_t id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/user-settings/user_settings.c
+++ b/user-settings/user_settings.c
@@ -484,3 +484,23 @@ const char *user_settings_id_to_key(uint16_t id)
 
 	return s->key;
 }
+
+size_t user_settings_get_max_len_with_key(const char *key)
+{
+	__ASSERT(prv_is_loaded, LOAD_ASSERT_TEXT);
+
+	struct user_setting *s = user_settings_list_get_by_key(key);
+	__ASSERT(s, "Key does not exists: %s", key);
+
+	return s->max_size;
+}
+
+size_t user_settings_get_max_len_with_id(uint16_t id)
+{
+	__ASSERT(prv_is_loaded, LOAD_ASSERT_TEXT);
+
+	struct user_setting *s = user_settings_list_get_by_id(id);
+	__ASSERT(s, "Id does not exists: %d", id);
+
+	return s->max_size;
+}


### PR DESCRIPTION
Two functions, enabling user to get max allowed length of a variable were added. 