### PR TITLE
Add restore default by key and id functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 -   Get default functions.
+-   Restore single setting functions.
 
 ## [1.3.1] - 2023-01-30
 

--- a/library/include/user_settings.h
+++ b/library/include/user_settings.h
@@ -132,6 +132,32 @@ int user_settings_set_default_with_id(uint16_t id, void *data, size_t len);
 void user_settings_restore_defaults(void);
 
 /**
+ * @brief Set setting value, defined by key to it's default value
+ *
+ * This will reset key specific setting value to its default and store it to NVS.
+ * If no default exists for a setting, the value is still deleted. Calls to
+ * @user_settings_get_with_*() will return NULL.
+ *
+ * @param[in] key The key of the setting to set
+ *
+ * @retval 0 on success
+ * @retval -EIO if no default exists for a setting
+ */
+int user_settings_restore_default_with_key(char *key);
+
+/**
+ * @brief Set setting value, defined by id to it's default value
+ *
+ * See @user_settings_restore_default_with_key()
+ *
+ * @param[in] id The ID of the setting to set
+ *
+ * @retval 0 on success
+ * @retval -EIO if no default exists for a setting
+ */
+int user_settings_restore_default_with_id(uint16_t id);
+
+/**
  * @brief Check if a user setting with the provided key exists
  *
  * @param[in] key The key to check

--- a/library/user_settings/user_settings.c
+++ b/library/user_settings/user_settings.c
@@ -310,6 +310,13 @@ static int prv_user_settings_set(struct user_setting *s, void *data, size_t len)
 	return 0;
 }
 
+static void prv_settings_restore(struct user_setting *setting)
+{
+	/* Clear the value. This will cause the default to be used on subsequent reads */
+	memset(setting->data, 0, setting->data_len);
+	setting->is_set = false;
+}
+
 void user_settings_restore_defaults(void)
 {
 	__ASSERT(prv_is_loaded, LOAD_ASSERT_TEXT);
@@ -321,11 +328,30 @@ void user_settings_restore_defaults(void)
 	user_settings_list_iter_start();
 	struct user_setting *setting;
 	while ((setting = user_settings_list_iter_next()) != NULL) {
-		if (setting->default_is_set) {
-			prv_user_settings_set(setting, setting->default_data,
-					      setting->default_data_len);
-		}
+		prv_settings_restore(setting);
 	}
+}
+
+int user_settings_restore_default_with_key(char *key)
+{
+	__ASSERT(prv_is_loaded, LOAD_ASSERT_TEXT);
+
+	struct user_setting *setting = user_settings_list_get_by_key(key);
+	__ASSERT(setting, "Key does not exists: %s", key);
+
+	prv_settings_restore(setting);
+	return 0;
+}
+
+int user_settings_restore_default_with_id(uint16_t id)
+{
+	__ASSERT(prv_is_loaded, LOAD_ASSERT_TEXT);
+
+	struct user_setting *setting = user_settings_list_get_by_id(id);
+	__ASSERT(setting, "ID does not exists: %d", id);
+
+	prv_settings_restore(setting);
+	return 0;
 }
 
 bool user_settings_exists_with_key(char *key)

--- a/tests/user_settings/src/main.c
+++ b/tests/user_settings/src/main.c
@@ -130,6 +130,26 @@ ZTEST(user_settings_suite, test_settings_default_value)
 	zassert_equal(value_out, value, "Value should be unchanged");
 }
 
+ZTEST(user_settings_suite, test_settings_restore_one)
+{
+	/* set value */
+	int8_t default_value = 0, value = -1;
+	user_settings_set_with_id(3, &value, 1);
+	user_settings_set_default_with_id(3, &default_value, 1);
+
+	/* value should be what was set */
+	int8_t value_out = *(int8_t *)user_settings_get_with_id(3, NULL);
+	zassert_equal(value_out, value, "Value should be %d before restore", value);
+
+	// /* restore default for this setting */
+	user_settings_restore_default_with_id(3);
+
+	/* value should be default */
+	int8_t value_out_after_restore = *(int8_t *)user_settings_get_with_id(3, NULL);
+	zassert_equal(value_out_after_restore, default_value, "Value should be %d after restore",
+		      default_value);
+}
+
 static uint32_t on_change_id_store;
 static const char *on_change_key_store;
 void on_change(uint32_t id, const char *key)


### PR DESCRIPTION
Add functions:
`int user_settings_restore_default_with_key(char *key)` and `int user_settings_restore_default_with_id(uint16_t id)` that allow user to reset individual setting to its default value. 