### PR TITLE
Add option to modify settings that were not changes when setting them from json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+-   user_settings_set_changed_with_key and user_settings_set_changed_with_id functions.
+-   always_mark_changed parameter to user_settings_set_from_json function.
+
 ## [1.5.0] - 2023-04-11
 
 ### Added

--- a/library/include/user_settings.h
+++ b/library/include/user_settings.h
@@ -507,6 +507,28 @@ bool user_settings_iter_next(char **key, uint16_t *id);
 bool user_settings_iter_next_changed(char **key, uint16_t *id);
 
 /**
+ * @brief Set the "has_changed_recently" flag
+ *
+ * This will assert if no setting with the provided key exists.
+ * If the key input for this function is unknown to the application (i.e. parsed from user), then
+ * it should first be checked with user_settings_exists_with_key().
+ *
+ * @param[in] key A valid user setting key
+ */
+void user_settings_set_changed_with_key(char *key);
+
+/**
+ * @brief Set the "has_changed_recently" flag
+ *
+ * This will assert if no setting with the provided id exists.
+ * If the ID input for this function is unknown to the application (i.e. parsed from user), then
+ * it should first be checked with user_settings_exists_with_id().
+ *
+ * @param[in] key A valid user setting id
+ */
+void user_settings_set_changed_with_id(uint16_t id);
+
+/**
  * @brief Clear "has_changed_recently" flag
  *
  * This will assert if no setting with the provided key exists.

--- a/library/include/user_settings_json.h
+++ b/library/include/user_settings_json.h
@@ -32,13 +32,16 @@ extern "C" {
  * }
  *
  * @param[in] settings The settings to apply
+ * @param[in] always_mark_changed If true, always mark settings as changed, even if the new value is
+ * the same as the old one. If false, a setting will only be marked
+ * changed if the new value is different from the old one.
  *
  * @retval 0 On success
  * @retval -ENOMEM If the new value is larger than the max_size
  * @retval -EIO if the setting value could not be stored to NVS
  * @retval -EINVAL if the invalid json structure
  */
-int user_settings_set_from_json(const cJSON *settings);
+int user_settings_set_from_json(const cJSON *settings, bool always_mark_changed);
 
 /**
  * @brief Create a JSON with containing only settings marked changed.

--- a/library/include/user_settings_json.h
+++ b/library/include/user_settings_json.h
@@ -45,9 +45,10 @@ int user_settings_set_from_json(const cJSON *settings, bool always_mark_changed)
 
 /**
  * @brief Create a JSON with containing only settings marked changed.
- * Function will not clear changed flag.
  *
- * The caller is expected to free  the created cJSON structure.
+ * Calling this function will not clear the changed flag of any user setting.
+ *
+ * The caller is expected to free the created cJSON structure.
  *
  * @param[out] settings Created json
  * @retval 0 On success
@@ -58,7 +59,7 @@ int user_settings_get_changed_json(cJSON **settings);
 /**
  * @brief Create a JSON with containing all settings.
  *
- * The caller is expected to free  the created cJSON structure.
+ * The caller is expected to free the created cJSON structure.
  *
  * @param[out] settings Created json
  * @retval 0 On success

--- a/library/user_settings/user_settings.c
+++ b/library/user_settings/user_settings.c
@@ -633,6 +633,26 @@ bool user_settings_iter_next_changed(char **key, uint16_t *id)
 	return true;
 }
 
+void user_settings_set_changed_with_key(char *key)
+{
+	__ASSERT(prv_is_loaded, LOAD_ASSERT_TEXT);
+
+	struct user_setting *s = user_settings_list_get_by_key(key);
+	__ASSERT(s, "Key does not exists: %s", key);
+
+	s->has_changed_recently = 1;
+}
+
+void user_settings_set_changed_with_id(uint16_t id)
+{
+	__ASSERT(prv_is_loaded, LOAD_ASSERT_TEXT);
+
+	struct user_setting *s = user_settings_list_get_by_id(id);
+	__ASSERT(s, "Id does not exists: %d", id);
+
+	s->has_changed_recently = 1;
+}
+
 void user_settings_clear_changed_with_key(char *key)
 {
 	__ASSERT(prv_is_loaded, LOAD_ASSERT_TEXT);


### PR DESCRIPTION
## Description

This PR adds `user_settings_set_changed_with_*` functions and then
uses them in `user_settings_set_from_json` to be able to also mark settings that were updated to the same value as changed.

This change is needed due to requirements in a project that uses this library.

## Areas of interest for the reviewer

All of the changes

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and write why  -->
- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- [x] I updated the CHANGELOG.
- [x] I updated all customer-facing technical documentation.

## After-review steps

<!--- Delete section or select one option -->
* I will merge PR by myself.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/dev/docs/developer_guidelines.md
