### PR TITLE
Store has_changed_recently flag in NVS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 -   user_settings_set_changed_with_key and user_settings_set_changed_with_id functions.
 -   always_mark_changed parameter to user_settings_set_from_json function.
+-   The "has_changed_recently" flag is now stored persistently.
+-   Shell commands to list only changed settings and to clear the changed flag.
 
 ## [1.5.0] - 2023-04-11
 


### PR DESCRIPTION
## Description

Stores the has_changed_recently flag in persistant storage, so that a reboot does not clear it.

Closes #42

## Areas of interest for the reviewer

All of the changes

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and write why  -->
- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- [x] I updated the CHANGELOG.
- [x] I updated all customer-facing technical documentation.

## After-review steps

<!--- Delete section or select one option -->
* I will merge PR by myself.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/dev/docs/developer_guidelines.md
