### PR TITLE
Add CONFIG_USER_SETTINGS_DEFAULT_OVERWRITE Kconfig option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+-  The CONFIG_USER_SETTINGS_DEFAULT_OVERWRITE option. If set, default values can be overwritten.
+
 ## [1.6.0] - 2023-05-12
 
 ### Added

--- a/library/Kconfig
+++ b/library/Kconfig
@@ -26,6 +26,13 @@ config USER_SETTINGS_JSON
 	depends on CJSON_LIB
 	default false
 
+config USER_SETTINGS_DEFAULT_OVERWRITE
+	bool "Allow default values to be overwritten"
+	default false
+	help
+	  If enabled, user_settings_set_default_with_key() will no longer return an
+	  error if a default already exists, but will replace it.
+
 module = USER_SETTINGS
 module-str = User settings
 source "subsys/logging/Kconfig.template.log_config"

--- a/library/include/user_settings.h
+++ b/library/include/user_settings.h
@@ -95,12 +95,17 @@ int user_settings_load(void);
  * If the key input for this function is unknown to the application (i.e. parsed from user), then
  * it should first be checked with user_settings_exists_with_key().
  *
+ * @note If overwriting default values is required, set CONFIG_USER_SETTINGS_DEFAULT_OVERWRITE=y.
+ * This can be used in use-cases where the default values are set form within the application, and a
+ * firmware update can change the default values. In that case, -EALREADY is never returned.
+ *
  * @param[in] key The key of the setting to set
  * @param[in] data The default value
  * @param[in] len The length of the default value (in bytes)
  *
  * @retval 0 on success
- * @retval -EALREADY if the default value has already been set
+ * @retval -EALREADY if the default value has already been set. Only returned if
+ * CONFIG_USER_SETTINGS_DEFAULT_OVERWRITE=n.
  * @retval -ENOMEM if len is >= then the max_size specified when adding the setting with
  * user_settings_add() or user_settings_add_sized()
  * @retval -EIO if the setting value could not be stored to NVS

--- a/library/user_settings/user_settings.c
+++ b/library/user_settings/user_settings.c
@@ -267,7 +267,7 @@ static int prv_user_settings_set_default(struct user_setting *s, void *data, siz
 	}
 
 	/* check if default already set */
-	if (s->default_is_set) {
+	if (!IS_ENABLED(CONFIG_USER_SETTINGS_DEFAULT_OVERWRITE) && s->default_is_set) {
 		LOG_ERR("Default already set for setting %s. Not setting new default. Clear NVS "
 			"first if you wish to change the default.",
 			s->key);

--- a/tests/user_settings/testcase.yaml
+++ b/tests/user_settings/testcase.yaml
@@ -1,3 +1,16 @@
 tests:
   user_settings.user_settings:
     platform_allow: native_posix
+    extra_configs:
+      # Disable fancy test, otherwise stdout parsing does not work.
+      - CONFIG_FANCY_ZTEST=n
+      - CONFIG_TEST_LOGGING_DEFAULTS=n
+      - CONFIG_ASSERT=n
+  user_settings.user_settings_with_default_override:
+    platform_allow: native_posix
+    extra_configs:
+      # Disable fancy test, otherwise stdout parsing does not work.
+      - CONFIG_FANCY_ZTEST=n
+      - CONFIG_TEST_LOGGING_DEFAULTS=n
+      - CONFIG_ASSERT=n
+      - CONFIG_USER_SETTINGS_DEFAULT_OVERWRITE=y


### PR DESCRIPTION
## Description

Allows default values to be changed.
Most of our firmware is currently written with the approach where the default values of the settings are set within the firmware itself. As opposed to setting defaults during factory provisioning.

This means that the firmware is the "controller" of the default settings, so it should be able to change them. This means that a firmware update can now change the default values.
If a non-default is set for a setting, it still remains across the FW update and will be used.

## Areas of interest for the reviewer

The code change, the documentation update, the tests.

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and write why  -->
- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- [x] I updated the CHANGELOG. 
- [x] I updated all customer-facing technical documentation.

## After-review steps

<!--- Delete section or select one option -->
* I will merge PR by myself.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/dev/docs/developer_guidelines.md
