### PR TITLE
feat: Settings iteration are now thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- User settings iteration is now thread-safe.
+
 ### Fixed
 
 - Removed Cmake warning when not enabling the library caused by no sources being added.

--- a/README.md
+++ b/README.md
@@ -98,13 +98,12 @@ For common validation cases, there are helper macros available in
 ## Iterators
 
 You can iterate trough existing settings using iterator functions. Call `user_settings_iter_start()`
-to reset iteration counters, then call `user_settings_iter_next(key, &id)` repeatedly to iterate
-trough all settings. When function returns `false` you have reached the end.
+to set up iteration, then call `user_settings_iter_next(key, &id)` repeatedly to iterate trough all
+settings. When function returns `false` you have reached the end.
 
 You can also iterate only trough recently set settings, i.e. with set flag `has_changed_recently`.
-Call `user_settings_iter_start()` to reset iteration counters, then call
-`user_settings_iter_next_changed(key, &id)` repeatedly to iterate trough all settings. When function
-returns `false` you have reached the end.
+Call `user_settings_iter_start()`, then call `user_settings_iter_next_changed(key, &id)` repeatedly
+to iterate trough all settings. When function returns `false` you have reached the end.
 
 ## JSON support
 
@@ -139,8 +138,8 @@ in mind you are responsible to delete the object. Function will not reset the fl
 
 A user setting bluetooth service can be enabled by setting `CONFIG_USER_SETTINGS_BT_SERVICE=y`. See
 the [bluetooth service sample](./samples/bluetooth_service) for details. The service uses the user
-settings binary protocol under the hood. For the protocol definition, see
-[here](./libraray/protocol/binary/README.md)
+settings binary protocol under the hood. For the protocol definition, see the
+[protocol definition docs](./libraray/protocol/binary/README.md)
 
 ## Development Setup
 
@@ -166,5 +165,5 @@ east update
 
 ### Setup `pre-commit`
 
-Turn on `pre-commit` tool by running `pre-commit install`. If you do not have it yet, follow
-instructions [here](https://github.com/IRNAS/irnas-guidelines-docs/tree/main/tools/pre-commit).
+Turn on `pre-commit` tool by running `pre-commit install`. If you do not have it yet, follow the
+[instructions](https://github.com/IRNAS/irnas-guidelines-docs/tree/main/tools/pre-commit).

--- a/library/include/user_settings.h
+++ b/library/include/user_settings.h
@@ -548,32 +548,37 @@ enum user_setting_type user_settings_get_type_with_id(uint16_t id);
 /**
  * @brief Start iteration over all user settings
  *
- * Call this before getting elements with user_settings_list_iter_next.
- * This will reset an in-progress iteration.
+ * Prepare the provided context for iteration over user settings.
+ *
+ * This must be called before calling other iteration functions.
+ *
+ * @param[in, out] ctx The context to use for the iteration.
  */
-void user_settings_iter_start(void);
+void user_settings_iter_start(struct user_settings_iter_ctx *ctx);
 
 /**
  * @brief Get next settings ID and KEY in the iteration
  *
+ * @param[in, out] ctx The context to use for the iteration.
  * @param[out] key The key of the next settings.
  * @param[out] id The ID of the next settings.
  *
  * @return True if we have next setting, false if there are no more.
  */
-bool user_settings_iter_next(char **key, uint16_t *id);
+bool user_settings_iter_next(struct user_settings_iter_ctx *ctx, char **key, uint16_t *id);
 
 /**
  * @brief Get next settings ID and KEY in the iteration
  *
  * Only returns settings with a set changed flag.
  *
+ * @param[in, out] ctx The context to use for the iteration.
  * @param[out] key The key of the next changed settings.
  * @param[out] id The ID of the next changed settings.
  *
  * @return True if we have next setting, false if there are no more.
  */
-bool user_settings_iter_next_changed(char **key, uint16_t *id);
+bool user_settings_iter_next_changed(struct user_settings_iter_ctx *ctx, char **key, uint16_t *id);
 
 /**
  * @brief Set the "has_changed_recently" flag

--- a/library/include/user_settings_types.h
+++ b/library/include/user_settings_types.h
@@ -70,6 +70,14 @@ enum user_setting_type {
 	USER_SETTINGS_TYPE_BYTES,
 };
 
+/**
+ * @brief Iterator context for user settings
+ */
+struct user_settings_iter_ctx {
+	sys_snode_t *iter_list_node;
+	bool iter_start;
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/protocol/executor/user_settings_protocol_executor.c
+++ b/library/protocol/executor/user_settings_protocol_executor.c
@@ -81,8 +81,9 @@ static int prv_exec_list_common(struct usp_executor *usp_executor, uspe_encode_t
 	int ret;
 	struct user_setting *us;
 
-	user_settings_list_iter_start();
-	while ((us = user_settings_list_iter_next()) != NULL) {
+	struct user_settings_iter_ctx ctx;
+	user_settings_list_iter_start(&ctx);
+	while ((us = user_settings_list_iter_next(&ctx)) != NULL) {
 		ret = encode(us, usp_executor->resp_buffer, usp_executor->resp_buffer_len);
 		if (ret < 0) {
 			__ASSERT(ret == -ENOMEM,

--- a/library/user_settings/user_settings.c
+++ b/library/user_settings/user_settings.c
@@ -445,10 +445,10 @@ void user_settings_restore_defaults(void)
 	/* by using prv_user_settings_set on each setting, the values will get stored and the
 	 * on_change callbacks will be called correctly
 	 */
-
-	user_settings_list_iter_start();
+	struct user_settings_iter_ctx ctx;
+	user_settings_list_iter_start(&ctx);
 	struct user_setting *setting;
-	while ((setting = user_settings_list_iter_next()) != NULL) {
+	while ((setting = user_settings_list_iter_next(&ctx)) != NULL) {
 		prv_settings_restore(setting);
 	}
 }
@@ -757,15 +757,15 @@ enum user_setting_type user_settings_get_type_with_id(uint16_t id)
 	return s->type;
 }
 
-void user_settings_iter_start(void)
+void user_settings_iter_start(struct user_settings_iter_ctx *ctx)
 {
-	user_settings_list_iter_start();
+	user_settings_list_iter_start(ctx);
 }
 
-bool user_settings_iter_next(char **key, uint16_t *id)
+bool user_settings_iter_next(struct user_settings_iter_ctx *ctx, char **key, uint16_t *id)
 {
 	struct user_setting *setting;
-	if ((setting = user_settings_list_iter_next()) != NULL) {
+	if ((setting = user_settings_list_iter_next(ctx)) != NULL) {
 		*key = setting->key;
 		*id = setting->id;
 		return true;
@@ -774,12 +774,12 @@ bool user_settings_iter_next(char **key, uint16_t *id)
 	}
 }
 
-bool user_settings_iter_next_changed(char **key, uint16_t *id)
+bool user_settings_iter_next_changed(struct user_settings_iter_ctx *ctx, char **key, uint16_t *id)
 {
 	bool prv_has_changed = 0;
 	struct user_setting *setting;
 	while (!prv_has_changed) {
-		if ((setting = user_settings_list_iter_next()) != NULL) {
+		if ((setting = user_settings_list_iter_next(ctx)) != NULL) {
 			prv_has_changed = setting->has_changed_recently;
 			if (prv_has_changed) {
 				*key = setting->key;
@@ -837,18 +837,20 @@ void user_settings_clear_changed(void)
 {
 	__ASSERT(prv_is_loaded, LOAD_ASSERT_TEXT);
 
-	user_settings_list_iter_start();
+	struct user_settings_iter_ctx ctx;
+	user_settings_list_iter_start(&ctx);
 	struct user_setting *setting;
-	while ((setting = user_settings_list_iter_next()) != NULL) {
+	while ((setting = user_settings_list_iter_next(&ctx)) != NULL) {
 		prv_set_changed_recently_flag(setting, 0);
 	}
 }
 
 bool user_settings_any_changed(void)
 {
-	user_settings_list_iter_start();
+	struct user_settings_iter_ctx ctx;
+	user_settings_list_iter_start(&ctx);
 	struct user_setting *setting;
-	while ((setting = user_settings_list_iter_next()) != NULL) {
+	while ((setting = user_settings_list_iter_next(&ctx)) != NULL) {
 		if (setting->has_changed_recently) {
 			return true;
 		}

--- a/library/user_settings/user_settings_json.c
+++ b/library/user_settings/user_settings_json.c
@@ -279,9 +279,10 @@ int user_settings_get_all_json(cJSON **settings_out)
 	}
 
 	/* Iterate trough settings */
-	user_settings_list_iter_start();
+	struct user_settings_iter_ctx ctx;
+	user_settings_list_iter_start(&ctx);
 	struct user_setting *setting_data;
-	while ((setting_data = user_settings_list_iter_next()) != NULL) {
+	while ((setting_data = user_settings_list_iter_next(&ctx)) != NULL) {
 		cJSON *setting = prv_json_from_setting(setting_data);
 		if (setting != NULL) {
 			cJSON_AddItemToObject(settings, setting_data->key, setting);
@@ -303,9 +304,10 @@ int user_settings_get_changed_json(cJSON **settings_out)
 	}
 
 	/* Iterate trough settings */
-	user_settings_list_iter_start();
+	struct user_settings_iter_ctx ctx;
+	user_settings_list_iter_start(&ctx);
 	struct user_setting *setting_data;
-	while ((setting_data = user_settings_list_iter_next()) != NULL) {
+	while ((setting_data = user_settings_list_iter_next(&ctx)) != NULL) {
 		if (setting_data->has_changed_recently) {
 			cJSON *setting = prv_json_from_setting(setting_data);
 			if (setting != NULL) {

--- a/library/user_settings/user_settings_list.c
+++ b/library/user_settings/user_settings_list.c
@@ -151,26 +151,24 @@ struct user_setting *user_settings_list_get_by_id(const uint16_t id)
 	return NULL;
 }
 
-static sys_snode_t *prv_iter_list_node = NULL;
-static bool iter_start = false;
-
-void user_settings_list_iter_start(void)
+void user_settings_list_iter_start(struct user_settings_iter_ctx *ctx)
 {
-	iter_start = true;
-	prv_iter_list_node = NULL;
+	__ASSERT(ctx, "Context cannot be NULL");
+	ctx->iter_start = true;
+	ctx->iter_list_node = NULL;
 }
 
-struct user_setting *user_settings_list_iter_next(void)
+struct user_setting *user_settings_list_iter_next(struct user_settings_iter_ctx *ctx)
 {
-	if (prv_iter_list_node == NULL && iter_start) {
-		prv_iter_list_node = sys_slist_peek_head(&prv_user_settings_list);
-		iter_start = false;
+	if (ctx->iter_list_node == NULL && ctx->iter_start) {
+		ctx->iter_list_node = sys_slist_peek_head(&prv_user_settings_list);
+		ctx->iter_start = false;
 	} else {
-		prv_iter_list_node = sys_slist_peek_next(prv_iter_list_node);
+		ctx->iter_list_node = sys_slist_peek_next(ctx->iter_list_node);
 	}
 
 	struct user_setting *us = NULL;
-	return SYS_SLIST_CONTAINER(prv_iter_list_node, us, list_node);
+	return SYS_SLIST_CONTAINER(ctx->iter_list_node, us, list_node);
 }
 
 void user_settings_list_free(void)

--- a/library/user_settings/user_settings_list.h
+++ b/library/user_settings/user_settings_list.h
@@ -144,7 +144,7 @@ void user_settings_list_free(void);
 /**
  * @brief Start iteration over the list
  */
-void user_settings_list_iter_start(void);
+void user_settings_list_iter_start(struct user_settings_iter_ctx *ctx);
 
 /**
  * @brief Get the next item in the list
@@ -153,7 +153,7 @@ void user_settings_list_iter_start(void);
  *
  * @return struct user_setting* The next item in the list
  */
-struct user_setting *user_settings_list_iter_next(void);
+struct user_setting *user_settings_list_iter_next(struct user_settings_iter_ctx *ctx);
 
 /**
  * @brief Get item in list by key

--- a/library/user_settings/user_settings_shell.c
+++ b/library/user_settings/user_settings_shell.c
@@ -108,9 +108,10 @@ static void prv_shell_print_setting(const struct shell *shell_ptr, struct user_s
 
 static int cmd_list(const struct shell *shell_ptr, size_t argc, char *argv[])
 {
-	user_settings_list_iter_start();
+	struct user_settings_iter_ctx ctx;
+	user_settings_list_iter_start(&ctx);
 	struct user_setting *setting;
-	while ((setting = user_settings_list_iter_next()) != NULL) {
+	while ((setting = user_settings_list_iter_next(&ctx)) != NULL) {
 		prv_shell_print_setting(shell_ptr, setting);
 	}
 
@@ -119,9 +120,10 @@ static int cmd_list(const struct shell *shell_ptr, size_t argc, char *argv[])
 
 static int cmd_list_changed(const struct shell *shell_ptr, size_t argc, char *argv[])
 {
-	user_settings_list_iter_start();
+	struct user_settings_iter_ctx ctx;
+	user_settings_list_iter_start(&ctx);
 	struct user_setting *setting;
-	while ((setting = user_settings_list_iter_next()) != NULL) {
+	while ((setting = user_settings_list_iter_next(&ctx)) != NULL) {
 		if (setting->has_changed_recently) {
 			prv_shell_print_setting(shell_ptr, setting);
 		}
@@ -286,10 +288,11 @@ static int cmd_clear_changed_one(const struct shell *shell_ptr, size_t argc, cha
  */
 static struct user_setting *prv_get_us_by_idx(size_t idx)
 {
-	user_settings_list_iter_start();
+	struct user_settings_iter_ctx ctx;
+	user_settings_list_iter_start(&ctx);
 	struct user_setting *setting;
 	int c = 0;
-	while ((setting = user_settings_list_iter_next()) != NULL) {
+	while ((setting = user_settings_list_iter_next(&ctx)) != NULL) {
 		if (idx == c) {
 			return setting;
 		}

--- a/tests/user_settings/src/main.c
+++ b/tests/user_settings/src/main.c
@@ -284,8 +284,9 @@ ZTEST(user_settings_suite, test_settings_iter_correct_count)
 	uint16_t id = 0;
 
 	/* Start iteration */
-	user_settings_iter_start();
-	while (user_settings_iter_next(&key, &id)) {
+	struct user_settings_iter_ctx ctx;
+	user_settings_iter_start(&ctx);
+	while (user_settings_iter_next(&ctx, &key, &id)) {
 		n_settings++;
 		zassert_equal(id, n_settings, "wrong id");
 	}
@@ -299,36 +300,37 @@ ZTEST(user_settings_suite, test_settings_iter_correct_key_and_id)
 	bool ret;
 
 	/* Start iteration */
-	user_settings_iter_start();
+	struct user_settings_iter_ctx ctx;
+	user_settings_iter_start(&ctx);
 
 	/* Assert that key and ID are returned as expected */
-	ret = user_settings_iter_next(&key, &id);
+	ret = user_settings_iter_next(&ctx, &key, &id);
 	zassert_true(ret, "Return value should be true");
 	zassert_equal(id, 1, "Id should be 1, was %d", id);
 	zassert_ok(strcmp(key, "t1"), "Key should be t1, was: %s", key);
 
-	ret = user_settings_iter_next(&key, &id);
+	ret = user_settings_iter_next(&ctx, &key, &id);
 	zassert_true(ret, "Return value should be true");
 	zassert_equal(id, 2, "Id should be 2, was %d", id);
 	zassert_ok(strcmp(key, "t2"), "Key should be t2, was: %s", key);
 
-	ret = user_settings_iter_next(&key, &id);
+	ret = user_settings_iter_next(&ctx, &key, &id);
 	zassert_true(ret, "Return value should be true");
 	zassert_equal(id, 3, "Id should be 3, was %d", id);
 	zassert_ok(strcmp(key, "t3"), "Key should be t3, was: %s", key);
 
-	ret = user_settings_iter_next(&key, &id);
+	ret = user_settings_iter_next(&ctx, &key, &id);
 	zassert_true(ret, "Return value should be true");
 	zassert_equal(id, 4, "Id should be 4, was %d", id);
 	zassert_ok(strcmp(key, "t4"), "Key should be t4, was: %s", key);
 
-	ret = user_settings_iter_next(&key, &id);
+	ret = user_settings_iter_next(&ctx, &key, &id);
 	zassert_true(ret, "Return value should be true");
 	zassert_equal(id, 5, "Id should be 5, was %d", id);
 	zassert_ok(strcmp(key, "t5"), "Key should be t5, was: %s", key);
 
 	/* Since we have 5 settings, we should get NULL here */
-	ret = user_settings_iter_next(&key, &id);
+	ret = user_settings_iter_next(&ctx, &key, &id);
 	zassert_false(ret, "Return value should be false");
 }
 
@@ -340,24 +342,25 @@ ZTEST(user_settings_suite, test_settings_iter_restart_midway)
 	bool ret;
 
 	/* Start iteration */
-	user_settings_iter_start();
+	struct user_settings_iter_ctx ctx;
+	user_settings_iter_start(&ctx);
 
 	/* Assert that key and ID are returned as expected */
-	ret = user_settings_iter_next(&key, &id);
+	ret = user_settings_iter_next(&ctx, &key, &id);
 	zassert_true(ret, "Return value should be true");
 	zassert_equal(id, 1, "Id should be 1, was %d", id);
 	zassert_ok(strcmp(key, "t1"), "Key should be t1, was: %s", key);
 
-	ret = user_settings_iter_next(&key, &id);
+	ret = user_settings_iter_next(&ctx, &key, &id);
 	zassert_true(ret, "Return value should be true");
 	zassert_equal(id, 2, "Id should be 2, was %d", id);
 	zassert_ok(strcmp(key, "t2"), "Key should be t2, was: %s", key);
 
 	/* Start again  */
-	user_settings_iter_start();
+	user_settings_iter_start(&ctx);
 
 	/* We should be back at first element */
-	ret = user_settings_iter_next(&key, &id);
+	ret = user_settings_iter_next(&ctx, &key, &id);
 	zassert_true(ret, "Return value should be true");
 	zassert_equal(id, 1, "Id should be 1, was %d", id);
 	zassert_ok(strcmp(key, "t1"), "Key should be t1, was: %s", key);
@@ -374,8 +377,9 @@ ZTEST(user_settings_suite, test_settings_changed_recently)
 	user_settings_clear_changed();
 
 	/* Start iteration */
-	user_settings_iter_start();
-	while (user_settings_iter_next_changed(&key, &id)) {
+	struct user_settings_iter_ctx ctx;
+	user_settings_iter_start(&ctx);
+	while (user_settings_iter_next_changed(&ctx, &key, &id)) {
 		n_changed++;
 	}
 	zassert_equal(n_changed, 0, "we cleared all, number of changed settings should be 0");
@@ -387,8 +391,8 @@ ZTEST(user_settings_suite, test_settings_changed_recently)
 
 	/* Start iteration */
 	n_changed = 0;
-	user_settings_iter_start();
-	while (user_settings_iter_next_changed(&key, &id)) {
+	user_settings_iter_start(&ctx);
+	while (user_settings_iter_next_changed(&ctx, &key, &id)) {
 		zassert_equal(id, 1, "changed id should be 1");
 		zassert_ok(strcmp(key, "t1"), "changed key should be t1");
 		n_changed++;
@@ -406,8 +410,8 @@ ZTEST(user_settings_suite, test_settings_changed_recently)
 
 	/* Start iteration */
 	n_changed = 0;
-	user_settings_iter_start();
-	while (user_settings_iter_next_changed(&key, &id)) {
+	user_settings_iter_start(&ctx);
+	while (user_settings_iter_next_changed(&ctx, &key, &id)) {
 		n_changed++;
 	}
 	zassert_equal(n_changed, 3, "we set 2 more, number of changed settings should be 3");
@@ -417,8 +421,8 @@ ZTEST(user_settings_suite, test_settings_changed_recently)
 
 	/* Start iteration */
 	n_changed = 0;
-	user_settings_iter_start();
-	while (user_settings_iter_next_changed(&key, &id)) {
+	user_settings_iter_start(&ctx);
+	while (user_settings_iter_next_changed(&ctx, &key, &id)) {
 		n_changed++;
 	}
 	zassert_equal(n_changed, 2, "we cleared 1 with id, number of changed settings should be 2");
@@ -428,8 +432,8 @@ ZTEST(user_settings_suite, test_settings_changed_recently)
 
 	/* Start iteration */
 	n_changed = 0;
-	user_settings_iter_start();
-	while (user_settings_iter_next_changed(&key, &id)) {
+	user_settings_iter_start(&ctx);
+	while (user_settings_iter_next_changed(&ctx, &key, &id)) {
 		n_changed++;
 	}
 	zassert_equal(n_changed, 1,
@@ -440,8 +444,8 @@ ZTEST(user_settings_suite, test_settings_changed_recently)
 
 	/* Start iteration */
 	n_changed = 0;
-	user_settings_iter_start();
-	while (user_settings_iter_next_changed(&key, &id)) {
+	user_settings_iter_start(&ctx);
+	while (user_settings_iter_next_changed(&ctx, &key, &id)) {
 		n_changed++;
 	}
 	zassert_equal(n_changed, 0, "we cleared all, number of changed settings should be 0");


### PR DESCRIPTION
# Description

Iteration used a global context, which makes it impossible to iterate twice at the same time.
The context is now passed to the iteration functions, so it is possible to iterate from multiple places at once.

Closes #51

## Areas of interest for the reviewer

All

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and
write why  -->

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- [x] I updated all customer-facing technical documentation.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
